### PR TITLE
Fixes #37: audit entries should include operation that was performed

### DIFF
--- a/src/main/java/com/redhat/lightblue/hook/audit/AuditHook.java
+++ b/src/main/java/com/redhat/lightblue/hook/audit/AuditHook.java
@@ -132,6 +132,7 @@ public class AuditHook implements CRUDHook {
         audit.setVersionText(processedDocument.getEntityMetadata().getVersion().getValue());
         audit.setLastUpdateDate(DateType.getDateFormat().format(processedDocument.getWhen()));
         audit.setLastUpdatedBy(processedDocument.getWho());
+        audit.setCRUDOperation(processedDocument.getCRUDOperation().toString());
 
         // attempt to get set of fields that identify the document from:
         //  1) pre doc

--- a/src/main/java/com/redhat/lightblue/hook/audit/model/Audit.java
+++ b/src/main/java/com/redhat/lightblue/hook/audit/model/Audit.java
@@ -19,6 +19,7 @@ public class Audit {
     private String versionText;
     private String lastUpdateDate;
     private String lastUpdatedBy;
+    private String CRUDOperation;
     private final List<AuditIdentity> identity = new ArrayList<>();
     private final Map<Path, AuditData> data = new HashMap<>();
 
@@ -91,6 +92,7 @@ public class Audit {
         toJSON(jsonNode, "versionText", getVersionText());
         toJSON(jsonNode, "lastUpdateDate", getLastUpdateDate());
         toJSON(jsonNode, "lastUpdatedBy", getLastUpdatedBy());
+        toJSON(jsonNode, "CRUDOperation", getCRUDOperation());
 
         if (identity != null && !identity.isEmpty()) {
             ArrayNode arrayJsonNode = jsonNode.putArray("identity");
@@ -117,5 +119,13 @@ public class Audit {
         if (name != null && !name.isEmpty() && value != null && !value.isEmpty()) {
             jsonNode.put(name, value);
         }
+    }
+
+    public void setCRUDOperation(String CRUDOperation) {
+        this.CRUDOperation = CRUDOperation;
+    }
+
+    public String getCRUDOperation() {
+        return CRUDOperation;
     }
 }

--- a/src/main/resources/metadata/audit.json
+++ b/src/main/resources/metadata/audit.json
@@ -49,6 +49,10 @@
                 "type": "string",
                 "description": "Who changed the field."
             },
+            "CRUDOperation": {
+                "type": "string",
+                "description": "The operation executed to change the field."
+            },
             "identity": {
                 "type": "array",
                 "description": "The fields that identify the audited document",

--- a/src/test/java/com/redhat/lightblue/hook/audit/AuditHookTest.java
+++ b/src/test/java/com/redhat/lightblue/hook/audit/AuditHookTest.java
@@ -10,6 +10,7 @@ import com.fasterxml.jackson.databind.node.JsonNodeFactory;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.github.fge.jsonschema.main.JsonSchema;
 import com.mongodb.DBCollection;
+import com.mongodb.DBCursor;
 import com.redhat.lightblue.crud.CRUDOperation;
 import com.redhat.lightblue.hooks.HookDoc;
 import com.redhat.lightblue.metadata.EntityMetadata;
@@ -127,7 +128,9 @@ public class AuditHookTest extends AbstractHookTest {
         
         // verify there's one audit in database
         // verify up front there is nothing in audit collection
-        Assert.assertEquals(1, auditColl.find().count());
+        DBCursor dbObjects = auditColl.find();
+        Assert.assertEquals(1, dbObjects.count());
+        System.out.println(dbObjects.next());
     }
 
     @Override


### PR DESCRIPTION
Issue https://github.com/lightblue-platform/lightblue-audit-hook/issues/37