### PR TITLE
auto-generate _id

### DIFF
--- a/src/main/resources/metadata/audit.json
+++ b/src/main/resources/metadata/audit.json
@@ -1,7 +1,7 @@
 {
     "entityInfo": {
         "name": "audit",
-        "defaultVersion": "1.0.1",
+        "defaultVersion": "1.0.2-SNAPSHOT",
         "datastore": {
             "backend": "mongo",
             "datasource": "mongo",
@@ -11,7 +11,7 @@
     "schema": {
         "name": "audit",
         "version": {
-            "value": "1.0.1",
+            "value": "1.0.2-SNAPSHOT",
             "changelog": "add CRUDOperation field"
         },
         "status": {
@@ -24,6 +24,15 @@
             "delete": ["anyone"]
         },
         "fields": {
+            "_id": {
+                "type": "string",
+                "constraints": {
+                    "identity": true
+                },
+                "valueGenerator": {
+                    "type": "UUID"
+                }
+            },
             "entityName": {
                 "type": "string",
                 "description": "Name of the entity audited",


### PR DESCRIPTION
Fixes this exception.

```
2015-09-30 09:55:09,992 [hystrix-UpdateCommand-10] ERROR [com.redhat.lightblue.hook.audit.AuditHook] {"data":{"entityName":"myEntity","versionText":"1.0.6-SNAPSHOT","lastUpdateDate":"20150930T09:55:09.929-0400","lastUpdatedBy":"me","CRUDOperation":"UPDATE","identity":[{"fieldText":"field1","valueText":"value1"},{"fieldText":"field2","valueText":"value2"}],"audits":[{"fieldText":"description","oldValue":"another new value, but from Dennis6","newValue":"another new value, but from Dennis7"}],"identity#":2,"audits#":1,"objectType":"audit"},"errors":[{"objectType":"error","context":"rest/UpdateCommand/myEntity/update(myEntity:1.0.6-SNAPSHOT)/audit/1.0.2-SNAPSHOT/insert(audit:null)/validateDocs/validateDoc/_id/identity","errorCode":"crud:Required","msg":"_id"}]}
```