### PR TITLE
no longer require entityName and version in config

### DIFF
--- a/src/main/java/com/redhat/lightblue/hook/audit/AuditHook.java
+++ b/src/main/java/com/redhat/lightblue/hook/audit/AuditHook.java
@@ -180,8 +180,7 @@ public class AuditHook implements CRUDHook, LightblueFactoryAware {
         AuditHookConfiguration auditConfig = (AuditHookConfiguration) cfg;
 
         try {
-            Error.push(auditConfig.getEntityName());
-            Error.push(auditConfig.getVersion());
+            Error.push(getName());
 
             // for each processed document
             for (HookDoc hd : processedDocuments) {

--- a/src/main/java/com/redhat/lightblue/hook/audit/AuditHookConfiguration.java
+++ b/src/main/java/com/redhat/lightblue/hook/audit/AuditHookConfiguration.java
@@ -7,25 +7,5 @@ import com.redhat.lightblue.metadata.HookConfiguration;
  * @author nmalik
  */
 public class AuditHookConfiguration implements HookConfiguration {
-    private final String entityName;
-    private final String version;
 
-    public AuditHookConfiguration(String entityName, String version) {
-        this.entityName = entityName;
-        this.version = version;
-    }
-
-    /**
-     * @return the entityName
-     */
-    public String getEntityName() {
-        return entityName;
-    }
-
-    /**
-     * @return the version
-     */
-    public String getVersion() {
-        return version;
-    }
 }

--- a/src/main/java/com/redhat/lightblue/hook/audit/AuditHookConfigurationParser.java
+++ b/src/main/java/com/redhat/lightblue/hook/audit/AuditHookConfigurationParser.java
@@ -1,6 +1,5 @@
 package com.redhat.lightblue.hook.audit;
 
-import com.fasterxml.jackson.databind.JsonNode;
 import com.redhat.lightblue.hooks.CRUDHook;
 import com.redhat.lightblue.metadata.HookConfiguration;
 import com.redhat.lightblue.metadata.parser.HookConfigurationParser;
@@ -12,8 +11,6 @@ import com.redhat.lightblue.metadata.parser.MetadataParser;
  * @author nmalik
  */
 public class AuditHookConfigurationParser<T> implements HookConfigurationParser<T> {
-    public static final String PROPERTY_ENTITY_NAME = "entityName";
-    public static final String PROPERTY_VERSION = "version";
 
     @Override
     public String getName() {
@@ -27,19 +24,11 @@ public class AuditHookConfigurationParser<T> implements HookConfigurationParser<
 
     @Override
     public HookConfiguration parse(String name, MetadataParser<T> p, T node) {
-        // note: name is the hook name (comes from generic Parser interface)
-        String entityName = p.getRequiredStringProperty(node, PROPERTY_ENTITY_NAME);
-        String version = p.getRequiredStringProperty(node, PROPERTY_VERSION);
-
-        return new AuditHookConfiguration(entityName, version);
+        return new AuditHookConfiguration();
     }
 
     @Override
     public void convert(MetadataParser<T> p, T emptyNode, HookConfiguration object) {
-        if (object instanceof AuditHookConfiguration) {
-            AuditHookConfiguration ahc = (AuditHookConfiguration) object;
-            p.putValue(emptyNode, PROPERTY_ENTITY_NAME, ahc.getEntityName());
-            p.putValue(emptyNode, PROPERTY_VERSION, ahc.getVersion());
-        }
+        //nothing to convert
     }
 }

--- a/src/test/java/com/redhat/lightblue/hook/audit/AuditHookConfigurationParserTest.java
+++ b/src/test/java/com/redhat/lightblue/hook/audit/AuditHookConfigurationParserTest.java
@@ -10,8 +10,6 @@ import org.junit.Test;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.redhat.lightblue.metadata.EntityInfo;
-import com.redhat.lightblue.metadata.MetadataConstants;
-import com.redhat.lightblue.util.Error;
 import com.redhat.lightblue.util.test.FileUtil;
 
 public class AuditHookConfigurationParserTest extends AbstractHookTest {
@@ -19,40 +17,6 @@ public class AuditHookConfigurationParserTest extends AbstractHookTest {
     @Test
     public void getName() {
         Assert.assertEquals(AuditHook.HOOK_NAME, hookParser.getName());
-    }
-
-    @Test
-    public void testMissingVersion() throws IOException, URISyntaxException {
-        String jsonString = FileUtil.readFile(getClass().getSimpleName() + "-missing-version.json");
-
-        Assert.assertNotNull(jsonString);
-
-        JsonNode node = json(jsonString);
-
-        try {
-            EntityInfo entityInfo = parser.parseEntityInfo(node);
-            Assert.fail("Expected Error to be thrown");
-        } catch (Error e) {
-            Assert.assertEquals(MetadataConstants.ERR_PARSE_MISSING_ELEMENT, e.getErrorCode());
-            Assert.assertEquals(AuditHookConfigurationParser.PROPERTY_VERSION, e.getMsg());
-        }
-    }
-
-    @Test
-    public void testMissingEntityName() throws IOException, URISyntaxException {
-        String jsonString = FileUtil.readFile(getClass().getSimpleName() + "-missing-entityName.json");
-
-        Assert.assertNotNull(jsonString);
-
-        JsonNode node = json(jsonString);
-
-        try {
-            EntityInfo entityInfo = parser.parseEntityInfo(node);
-            Assert.fail("Expected Error to be thrown");
-        } catch (Error e) {
-            Assert.assertEquals(MetadataConstants.ERR_PARSE_MISSING_ELEMENT, e.getErrorCode());
-            Assert.assertEquals(AuditHookConfigurationParser.PROPERTY_ENTITY_NAME, e.getMsg());
-        }
     }
 
     @Test
@@ -84,10 +48,6 @@ public class AuditHookConfigurationParserTest extends AbstractHookTest {
         Assert.assertNotNull(entityInfo);
         Assert.assertFalse(entityInfo.getHooks().isEmpty());
         Assert.assertEquals(AuditHook.HOOK_NAME, entityInfo.getHooks().getHooks().get(0).getName());
-
-        // verify configuration
-        Assert.assertEquals("audit", ((AuditHookConfiguration) entityInfo.getHooks().getHooks().get(0).getConfiguration()).getEntityName());
-        Assert.assertEquals("1.0.0", ((AuditHookConfiguration) entityInfo.getHooks().getHooks().get(0).getConfiguration()).getVersion());
     }
 
     @Test
@@ -98,8 +58,7 @@ public class AuditHookConfigurationParserTest extends AbstractHookTest {
 
         AuditHookConfiguration config = (AuditHookConfiguration) p.parse("audit", parser, json(jsonString));
 
-        Assert.assertEquals("audit", config.getEntityName());
-        Assert.assertEquals("1.0.0", config.getVersion());
+        Assert.assertNotNull(config);
     }
 
     @Test
@@ -114,8 +73,7 @@ public class AuditHookConfigurationParserTest extends AbstractHookTest {
 
         p.convert(parser, node, config);
 
-        Assert.assertEquals("audit", node.get("entityName").asText());
-        Assert.assertEquals("1.0.0", node.get("version").asText());
+        Assert.assertFalse(node.elements().hasNext());
     }
 
     @Override

--- a/src/test/java/com/redhat/lightblue/hook/audit/AuditHookTest.java
+++ b/src/test/java/com/redhat/lightblue/hook/audit/AuditHookTest.java
@@ -96,7 +96,7 @@ public class AuditHookTest extends AbstractHookTest {
         EntityMetadata fooMetadata = parser.parseEntityMetadata(json(FileUtil.readFile(FOO_METADATA_FILENAME)));
 
         // create audit hook configuration
-        AuditHookConfiguration config = new AuditHookConfiguration("foo", "0.1.0-SNAPSHOT");
+        AuditHookConfiguration config = new AuditHookConfiguration();
 
         // ------------------------------------------------------------
         // mock up document data

--- a/src/test/java/com/redhat/lightblue/hook/audit/CountryAuditHookTest.java
+++ b/src/test/java/com/redhat/lightblue/hook/audit/CountryAuditHookTest.java
@@ -99,7 +99,7 @@ public class CountryAuditHookTest extends AbstractHookTest {
         EntityMetadata em = parser.parseEntityMetadata(json(jsonSchemaString));
 
         // create hook configuration
-        AuditHookConfiguration config = new AuditHookConfiguration(em.getName(), em.getVersion().getValue());
+        AuditHookConfiguration config = new AuditHookConfiguration();
 
         // ------------------------------------------------------------
         // mock up document data
@@ -137,7 +137,7 @@ public class CountryAuditHookTest extends AbstractHookTest {
         EntityMetadata em = parser.parseEntityMetadata(json(jsonSchemaString));
 
         // create hook configuration
-        AuditHookConfiguration config = new AuditHookConfiguration(em.getName(), em.getVersion().getValue());
+        AuditHookConfiguration config = new AuditHookConfiguration();
 
         // ------------------------------------------------------------
         // mock up document data
@@ -179,7 +179,7 @@ public class CountryAuditHookTest extends AbstractHookTest {
         EntityMetadata em = parser.parseEntityMetadata(json(jsonSchemaString));
 
         // create hook configuration
-        AuditHookConfiguration config = new AuditHookConfiguration(em.getName(), em.getVersion().getValue());
+        AuditHookConfiguration config = new AuditHookConfiguration();
 
         // ------------------------------------------------------------
         // mock up document data
@@ -220,7 +220,7 @@ public class CountryAuditHookTest extends AbstractHookTest {
         EntityMetadata em = parser.parseEntityMetadata(json(jsonSchemaString));
 
         // create hook configuration
-        AuditHookConfiguration config = new AuditHookConfiguration(em.getName(), em.getVersion().getValue());
+        AuditHookConfiguration config = new AuditHookConfiguration();
 
         // ------------------------------------------------------------
         // mock up document data
@@ -269,7 +269,7 @@ public class CountryAuditHookTest extends AbstractHookTest {
         EntityMetadata em = parser.parseEntityMetadata(json(jsonSchemaString));
 
         // create hook configuration
-        AuditHookConfiguration config = new AuditHookConfiguration(em.getName(), em.getVersion().getValue());
+        AuditHookConfiguration config = new AuditHookConfiguration();
 
         // ------------------------------------------------------------
         // mock up document data

--- a/src/test/resources/metadata/country_with_hooks.json
+++ b/src/test/resources/metadata/country_with_hooks.json
@@ -4,10 +4,6 @@
         "hooks": [
             {
                 "name": "auditHook",
-                "configuration": {
-                    "entityName": "audit",
-                    "version": "1.0.1"
-                },
                 "actions": [
                     "insert",
                     "update",


### PR DESCRIPTION
There is no need to require entityName and version be specified in the audit configs. Just use the default version.